### PR TITLE
use variable

### DIFF
--- a/docker-ubuntu.pkr.hcl
+++ b/docker-ubuntu.pkr.hcl
@@ -35,6 +35,6 @@ build {
   }
   # This provisioner runs last
   provisioner "shell" {
-    inline = ["echo This provisioner runs last"]
+    inline = ["echo Running ${var.docker_image} Docker image."]
   }
 }


### PR DESCRIPTION
## Ref

https://developer.hashicorp.com/packer/tutorials/docker-get-started/docker-get-started-variables

## Why

use variable

## What

```console
[2023/11/08 09:37:11] sakabekodai@~/src/github.com/koudaiii/packer_tutorial (koudaiii/add-variable)(minikube)
$ packer build docker-ubuntu.pkr.hcl 
learn-packer.docker.ubuntu: output will be in this color.

==> learn-packer.docker.ubuntu: Creating a temporary directory for sharing data...
==> learn-packer.docker.ubuntu: Pulling Docker image: ubuntu:xenial
    learn-packer.docker.ubuntu: xenial: Pulling from library/ubuntu
    learn-packer.docker.ubuntu: Digest: sha256:1f1a2d56de1d604801a9671f301190704c25d604a416f59e03c04f5c6ffee0d6
    learn-packer.docker.ubuntu: Status: Image is up to date for ubuntu:xenial
    learn-packer.docker.ubuntu: docker.io/library/ubuntu:xenial
    learn-packer.docker.ubuntu: What's Next?
    learn-packer.docker.ubuntu: View a summary of image vulnerabilities and recommendations → docker scout quickview ubuntu:xenial
==> learn-packer.docker.ubuntu: Starting docker container...
    learn-packer.docker.ubuntu: Run command: docker run -v /Users/sakabekodai/.config/packer/tmp1832840963:/packer-files -d -i -t --entrypoint=/bin/sh -- ubuntu:xenial
    learn-packer.docker.ubuntu: Container ID: 44633d56ee3bbcca166f94fa00a321d5e28efe6dc07af879ad682e4302da128c
==> learn-packer.docker.ubuntu: Using docker communicator to connect: 172.17.0.3
==> learn-packer.docker.ubuntu: Provisioning with shell script: /var/folders/jt/yc369n416rvd6l0d2zm7ng8h0000gn/T/packer-shell3453775341
    learn-packer.docker.ubuntu: Adding file to Docker Container
==> learn-packer.docker.ubuntu: Provisioning with shell script: /var/folders/jt/yc369n416rvd6l0d2zm7ng8h0000gn/T/packer-shell3599386700
    learn-packer.docker.ubuntu: Running ubuntu:xenial Docker image.
==> learn-packer.docker.ubuntu: Committing the container
    learn-packer.docker.ubuntu: Image ID: sha256:10c1f274f90512fbebee1c46f61237f06eb9c74fc7222e5926df84ec23026cd3
==> learn-packer.docker.ubuntu: Killing the container: 44633d56ee3bbcca166f94fa00a321d5e28efe6dc07af879ad682e4302da128c
Build 'learn-packer.docker.ubuntu' finished after 6 seconds 785 milliseconds.

==> Wait completed after 6 seconds 786 milliseconds

==> Builds finished. The artifacts of successful builds are:
--> learn-packer.docker.ubuntu: Imported Docker image: sha256:10c1f274f90512fbebee1c46f61237f06eb9c74fc7222e5926df84ec23026cd3
```